### PR TITLE
update: sqlight to v1.0.0 and simplifile to v2.0.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -11,10 +11,10 @@ gleam = ">= 0.32.0"
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.35 or ~> 1.0"
-sqlight = "~> 0.9"
-simplifile = "~> 1.4"
+gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+sqlight = ">= 1.0.0 and < 2.0.0"
+simplifile = ">= 2.0.0 and < 3.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
-gleam_erlang = "~> 0.24"
+gleeunit = ">= 1.0.0"
+gleam_erlang = ">= 0.24.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,17 +2,18 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "esqlite", version = "0.8.6", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "607E45F4DA42601D8F530979417F57A4CD629AB49085891849302057E68EA188" },
-  { name = "gleam_erlang", version = "0.24.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "26BDB52E61889F56A291CB34167315780EE4AA20961917314446542C90D1C1A0" },
-  { name = "gleam_stdlib", version = "0.35.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5443EEB74708454B65650FEBBB1EF5175057D1DEC62AEA9D7C6D96F41DA79152" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
-  { name = "simplifile", version = "1.4.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "C93A62CE23B2E44F969DC3134F9EE899C362B0A2F4181233CDD5D759F82EE486" },
-  { name = "sqlight", version = "0.9.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "2D9C9BA420A5E7DCE7DB2DAAE4CAB0BE6218BEB48FD1531C583550B3D1316E94" },
+  { name = "esqlite", version = "0.8.9", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "465AE9AE28AE4192EA54C829FDC90C320447D439A9B2E10946621672FC6A6F8C" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
+  { name = "gleam_stdlib", version = "0.59.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F8FEE9B35797301994B81AF75508CF87C328FE1585558B0FFD188DC2B32EAA95" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
+  { name = "simplifile", version = "2.2.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "C88E0EE2D509F6D86EB55161D631657675AA7684DAB83822F7E59EB93D9A60E3" },
+  { name = "sqlight", version = "1.0.1", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "5435662352757841F9395C933404A223F39F73C73C4EC5E4418A7CB8AE85CDE6" },
 ]
 
 [requirements]
-gleam_erlang = { version = "~> 0.24"}
-gleam_stdlib = { version = "~> 0.35 or ~> 1.0" }
-gleeunit = { version = "~> 1.0" }
-simplifile = { version = "~> 1.4" }
-sqlight = { version = "~> 0.9" }
+gleam_erlang = { version = ">= 0.24.0" }
+gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.0.0" }
+simplifile = { version = ">= 2.2.1 and < 3.0.0" }
+sqlight = { version = ">= 1.0.1 and < 2.0.0" }

--- a/src/migrant.gleam
+++ b/src/migrant.gleam
@@ -1,6 +1,5 @@
-import gleam/io
-import migrant/filesystem
 import migrant/database
+import migrant/filesystem
 import migrant/types.{type Error}
 import sqlight
 
@@ -15,7 +14,7 @@ pub fn migrate(
   case database.apply_migrations(db, migrations) {
     Ok(_) -> Ok(Nil)
     Error(err) -> {
-      io.debug(err)
+      echo err
       panic as "Something went horribly wrong, see above for details. If you think this is a bug, please open an issue at https://github.com/aosasona/migrant"
     }
   }

--- a/src/migrant/filesystem.gleam
+++ b/src/migrant/filesystem.gleam
@@ -1,14 +1,14 @@
-import gleam/io
 import gleam/bool
-import gleam/string
 import gleam/dict
+import gleam/io
 import gleam/option.{type Option, None, Some}
 import gleam/result
+import gleam/string
+import migrant/lib
 import migrant/types.{
   type Error, type Migrations, ExpectedFolderError, ExtractionError, FileError,
   Migration,
 }
-import migrant/lib
 import simplifile
 
 pub fn load_migration_files(
@@ -27,7 +27,7 @@ pub fn load_migration_files(
 
 fn is_directory(path: String, next: fn(String) -> Result(Nil, Error)) {
   use is_dir <- result.try(
-    simplifile.verify_is_directory(path)
+    simplifile.is_directory(path)
     |> result.map_error(FileError),
   )
   use <- bool.guard(when: is_dir, return: next(path))
@@ -85,16 +85,16 @@ fn parse_files(
             None ->
               Error(ExtractionError(
                 "Invalid migration direction, expected one of `up` or `down`, got `"
-                  <> direction
-                  <> "`",
+                <> direction
+                <> "`",
               ))
           }
         }
         _ -> {
           Error(ExtractionError(
             "Failed to extract up/down from "
-              <> file
-              <> ". Migration files must be named in the format <name>.<up/down>.sql e.g 00001_create_users.up.sql",
+            <> file
+            <> ". Migration files must be named in the format <name>.<up/down>.sql e.g 00001_create_users.up.sql",
           ))
         }
       }

--- a/test/migrant_test.gleam
+++ b/test/migrant_test.gleam
@@ -1,8 +1,7 @@
+import gleam/erlang
+import gleam/result
 import gleeunit
 import gleeunit/should
-import gleam/erlang
-import gleam/io
-import gleam/result
 import migrant
 import simplifile
 import sqlight
@@ -33,7 +32,7 @@ fn priv_dir() -> String {
   case erlang.priv_directory("migrant") {
     Ok(dir) -> dir
     Error(e) -> {
-      io.debug(e)
+      echo e
       panic as "^^ Failed to get priv directory ^^"
     }
   }
@@ -52,10 +51,10 @@ fn setup() -> Nil {
   let _ = simplifile.create_directory(priv_dir())
 
   // Create the db file if it doesn't exist
-  let is_file = case simplifile.verify_is_file(db_path()) {
+  let is_file = case simplifile.is_file(db_path()) {
     Ok(is_file) -> is_file
     Error(e) -> {
-      io.debug(e)
+      echo e
       panic as "^^ Failed to check for existence of db file ^^"
     }
   }


### PR DESCRIPTION
Hello!

This library is perfect for what I need, but it currently has version conflicts with the latest versions of Gleam, Sqlight, and simplifile. I forked the project and fixed it myself, and figured my update might be appreciated upstream.

Here are the things that changed:
- Gleam: `io.debug` became `echo`
- Sqlight: since v1.0.0, it is now using Gleam's [`decode`](https://hexdocs.pm/gleam_stdlib/gleam/dynamic/decode.html) module
- Simplifile: Since v2.0.0, `verify_is_file` became `is_file` and `verify_is_directory` became `is_directory`