### PR TITLE
fix: change rollback mechanism to use a transaction

### DIFF
--- a/src/migrant/types.gleam
+++ b/src/migrant/types.gleam
@@ -10,7 +10,6 @@ pub type Error {
   ExtractionError(message: String)
   DatabaseError(sqlight.Error)
   MigrationError(message: String, err: Error)
-  RollbackError
 }
 
 pub type Migration {


### PR DESCRIPTION
Hello again!

While using this library, I noticed that when a migration fails, it'll try to rollback using a user-provided down migration. If the user does not provide a correct down migration, this library fails and may leave the database in an inconsistent state between migrations. Here's an example:

```SQL
-- some-migration.up.sql

ALTER TABLE foo ADD COLUMN bar TEXT; -- this will work

UPDATE foo SET; -- This will fail.

ALTER TABLE foo ADD COLUMN baz INTEGER; -- this will never be executed because the migration failed in the previous statement

-- some-migration.down.sql

ALTER TABLE foo DROP COLUMN baz; -- this will fail, since baz was not created
ALTER TABLE foo DROP COLUMN bar; -- this will never be executed, because the query failed in the previous statement
```

To fix this, I changed the rollback mechanism to rely on a [transaction](https://www.sqlite.org/lang_transaction.html). This will never leave the database in an inconsistent state, and will not rely on user-provided down migrations.